### PR TITLE
解决搜索栏页面上滑显示背景的bug #16

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -9,13 +9,13 @@
             <!--搜索框 只在“微信”和“通讯录”页面下显示-->
             <search v-show="$route.path.indexOf('explore')===-1&&$route.path.indexOf('self')===-1"></search>
             <!--四个门面页 “微信” “通讯录” “发现” “我”-->
-            <section class="app-content">
+            <section class="app-content" v-show="$store.state.headerStatus">
                 <keep-alive>
                     <router-view name="default" ></router-view>
                 </keep-alive>
             </section>
             <!--底部导航 路由 -->
-            <footer class="app-footer">
+            <footer class="app-footer" v-show="$store.state.headerStatus">
                 <wx-nav></wx-nav>
             </footer>
         </div>


### PR DESCRIPTION
打开搜索栏时隐藏内容页和底部导航。

其他的几点建议：
1. 搜索栏可滑动，可以设置其定位fixed    
1. 点击搜索微信出现红字（"防欺诈盗号，请勿支付或输入QQ密码"），可以在公众号填写安全域名[点我](http://jingyan.baidu.com/article/20095761b8a15dcb0721b4dd.html)    